### PR TITLE
Expose GTFS pickup_type per departure (arriving vs departing)

### DIFF
--- a/custom_components/auckland_transport/sensor.py
+++ b/custom_components/auckland_transport/sensor.py
@@ -280,6 +280,7 @@ class RealtimeDataCoordinator(DataUpdateCoordinator):
                 "stop_headsign": attributes.get("stop_headsign"),
                 "route_id": attributes.get("route_id"),
                 "trip_id": attributes.get("trip_id"),
+                "pickup_type": attributes.get("pickup_type"),
             }
             
             trips.append(trip_data)
@@ -564,6 +565,9 @@ class AucklandTransportSensor(CoordinatorEntity, SensorEntity):
                 attrs[f"{prefix}_headsign"] = arrival.get("trip_headsign")
                 attrs[f"{prefix}_route"] = arrival.get("route_id")
                 attrs[f"{prefix}_trip_id"] = arrival.get("trip_id")
+                # GTFS pickup_type: 1 = no boarding here, i.e. the service
+                # terminates at this stop (arriving). 0 = boardable (departing).
+                attrs[f"{prefix}_pickup_type"] = arrival.get("pickup_type")
                 
                 # Use departure_qty to control how many departures are getting added
                 # If departure_qty is None, show all departures (don't break)


### PR DESCRIPTION
## What

Surfaces the GTFS **`pickup_type`** field already returned by
`/stops/{id}/stoptrips` as a per-departure attribute
(`departure_N_pickup_type`).

## Why

`pickup_type` is the GTFS-canonical signal for whether a vehicle is **arriving**
or **departing** at a stop:

- `pickup_type == 1` → no boarding here → the service **terminates** at this
  stop → *arriving*
- `pickup_type == 0` → boardable → *departing / through*

The data is already fetched; this just stops discarding it. It lets cards show
an arrival/departure indicator that's correct at **every** stop type, not only
terminuses.

Verified against live data for Pukekohe Train Station (`134-b31c4580`):

| trip_headsign | pickup_type | stop_sequence | meaning |
|---|---|---|---|
| Pukekohe 1 To Brit 4 … | 0 | 1 (first) | departing (originates) |
| Brit 4 To Pukekohe 1 … | 1 | 17 (last) | arriving (terminates) |

## Scope / recorder note

Deliberately limited to **one** extra attribute per departure. Since the sensor
publishes every remaining departure for the day, adding several fields each can
push total state attributes past the recorder's 16 KB limit (`State attributes
… exceed maximum size of 16384 bytes`). `pickup_type` alone is enough for the
arriving/departing distinction.

## Compatibility

Purely additive — existing attributes and behaviour are unchanged; older cards
simply ignore the new attribute.

## Companion

Card support (with a heuristic fallback when this attribute isn't present):
SeitzDaniel/auckland-transport-card#1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
